### PR TITLE
Update fields to dynamic search values for static HTML elements

### DIFF
--- a/pkg/printer/http_settings.go
+++ b/pkg/printer/http_settings.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -14,6 +15,60 @@ const urlHttpCertServerSettings = "net/net/certificate/http.html"
 var (
 	errCurrentCertIdNotFound = errors.New("printer: get: failed to find current cert id")
 )
+
+// httpSettingsFormFields holds the dynamically discovered form field names for the HTTP settings page
+type httpSettingsFormFields struct {
+	certSelectField string // certificate select dropdown (e.g., B903 or Bb23)
+	httpsWebField   string // HTTPS checkbox for WebUI (e.g., B86c or Ba8c)
+	httpsIppField   string // HTTPS checkbox for IPP (e.g., B87e or Ba9e)
+}
+
+// parseHttpSettingsFormFields extracts the form field names from the HTTP settings page HTML
+func parseHttpSettingsFormFields(bodyBytes []byte) (*httpSettingsFormFields, error) {
+	fields := &httpSettingsFormFields{}
+
+	// Find the select element for certificate selection
+	// Pattern: <select id="Bb23" name="Bb23" ...>
+	selectRegex := regexp.MustCompile(`<select[^>]+(?:id="([^"]+)"[^>]+name="([^"]+)"|name="([^"]+)"[^>]+id="([^"]+)")[^>]*>`)
+	selectMatch := selectRegex.FindSubmatch(bodyBytes)
+	if len(selectMatch) >= 2 {
+		if len(selectMatch[1]) > 0 {
+			fields.certSelectField = string(selectMatch[1])
+		} else if len(selectMatch[3]) > 0 {
+			fields.certSelectField = string(selectMatch[3])
+		}
+	}
+
+	// Find HTTPS checkboxes - look for checkboxes with HTTPS in surrounding context
+	// The WebUI HTTPS checkbox typically has id like "Ba8c" and is near "HTTPS(Port 443)" text
+	// Pattern: <input type="checkbox" id="Ba8c" name="Ba8c" value="1" checked="checked" />HTTPS
+	httpsCheckboxRegex := regexp.MustCompile(`<input[^>]+type="checkbox"[^>]+(?:id="([^"]+)"[^>]+name="([^"]+)"|name="([^"]+)"[^>]+id="([^"]+)")[^>]+value="1"[^>]*>[^<]*HTTPS`)
+	httpsMatches := httpsCheckboxRegex.FindAllSubmatch(bodyBytes, -1)
+
+	for i, match := range httpsMatches {
+		var fieldName string
+		if len(match[1]) > 0 {
+			fieldName = string(match[1])
+		} else if len(match[3]) > 0 {
+			fieldName = string(match[3])
+		}
+
+		if fieldName != "" {
+			if i == 0 {
+				fields.httpsWebField = fieldName
+			} else if i == 1 {
+				fields.httpsIppField = fieldName
+			}
+		}
+	}
+
+	// Validate we found required fields
+	if fields.certSelectField == "" {
+		return nil, errors.New("printer: http settings: failed to find certificate select field name")
+	}
+
+	return fields, nil
+}
 
 // getHttpSettings fetches the HTTP Server Settings page
 func (p *printer) getHttpSettings() ([]byte, error) {
@@ -67,15 +122,25 @@ func (p *printer) SetActiveCert(id string) error {
 		return err
 	}
 
+	// parse form field names from the HTTP settings page HTML
+	formFields, err := parseHttpSettingsFormFields(bodyBytes)
+	if err != nil {
+		return err
+	}
+
 	// submit initial form to change the cert
 	data := url.Values{}
 	data.Set("pageid", "326")
 	data.Set("CSRFToken", csrfToken)
-	data.Set("B903", id)
-	// B91d always seems to be 1, but wasn't needed here
-	// Enable HTTPS for WebUI and IPP
-	data.Set("B86c", "1")
-	data.Set("B87e", "1")
+	// use dynamically discovered certificate select field name
+	data.Set(formFields.certSelectField, id)
+	// Enable HTTPS for WebUI and IPP using dynamically discovered field names
+	if formFields.httpsWebField != "" {
+		data.Set(formFields.httpsWebField, "1")
+	}
+	if formFields.httpsIppField != "" {
+		data.Set(formFields.httpsIppField, "1")
+	}
 	// there are some other values here but don't set them (which should
 	// leave them as-is in most cases)
 


### PR DESCRIPTION
Greg,

This is a continuation of https://github.com/gregtwallace/brother-cert/pull/2 as I found more fields and should solve https://github.com/gregtwallace/brother-cert/issues/3 as well by using dynamic field scans across the board.

This is tested against a MFC-L2750DW printer and worked from both Cert Warden and via local tests on my MBP. I hope this helps and sorry for not catching this the first time. Oddly I noticed this issue after 90+ days when we were unable to print when the cert expired and Uptime Kuma wasn't configured to continually re notify.